### PR TITLE
feat: support clickable hyperlinks in message content

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -451,6 +451,9 @@ addEventListener('DOMContentLoaded', () => {
                 else return `<span class="mention interactive">@${match.includes('&#38;') ? 'role' : 'user'}</span>`
             })
 
+            // parse text in brackets and then the URL in parentheses.
+            .replace(/\[([^\[\]]+)\]\((.+?)\)/g, `<a title="$1" target="_blank" class="anchor" href="$2">$1</a>`)
+    
         if (inlineBlock)
             // Treat both inline code and code blocks as inline code
             txt = txt.replace(/`([^`]+?)`|``([^`]+?)``|```((?:\n|.)+?)```/g, (m, x, y, z) => x ? `<code class="inline">${x}</code>` : y ? `<code class="inline">${y}</code>` : z ? `<code class="inline">${z}</code>` : m);
@@ -463,10 +466,6 @@ addEventListener('DOMContentLoaded', () => {
             // Inline code
             txt = txt.replace(/`([^`]+?)`|``([^`]+?)``/g, (m, x, y, z) => x ? `<code class="inline">${x}</code>` : y ? `<code class="inline">${y}</code>` : z ? `<code class="inline">${z}</code>` : m)
         }
-
-        // URL parse
-        txt = txt.replace(/\[([^\[\]]+)\]\((.+?)\)/g, `<a title="$1" target="_blank" class="anchor" href="$2">$1</a>`);
-
         return txt;
     }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -464,8 +464,8 @@ addEventListener('DOMContentLoaded', () => {
             txt = txt.replace(/`([^`]+?)`|``([^`]+?)``/g, (m, x, y, z) => x ? `<code class="inline">${x}</code>` : y ? `<code class="inline">${y}</code>` : z ? `<code class="inline">${z}</code>` : m)
         }
 
-        if (inEmbed)
-            txt = txt.replace(/\[([^\[\]]+)\]\((.+?)\)/g, `<a title="$1" target="_blank" class="anchor" href="$2">$1</a>`);
+        // URL parse
+        txt = txt.replace(/\[([^\[\]]+)\]\((.+?)\)/g, `<a title="$1" target="_blank" class="anchor" href="$2">$1</a>`);
 
         return txt;
     }


### PR DESCRIPTION
The new Discord markdown system allowed the ability to insert clickable hyperlinks into normal messages so we could remove the restriction now.
![image](https://github.com/Glitchii/embedbuilder/assets/69383979/c4280f14-386b-4c5c-81dc-1373d66df638)
