### PR TITLE
Fix XSS vulnerabilities in markdown links and embed titles

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -456,7 +456,11 @@ addEventListener('DOMContentLoaded', () => {
             })
 
             // parse text in brackets and then the URL in parentheses.
-            .replace(/\[([^\[\]]+)\]\((.+?)\)/g, `<a title="$1" target="_blank" class="anchor" href="$2">$1</a>`)
+            .replace(/\[([^\[\]]+)\]\((.+?)\)/g, (_, text, href) => {
+                if (!/^https?:\/\//i.test(href)) return text;
+                const safeHref = href.replace(/"/g, '&quot;');
+                return `<a title="${encodeHTML(text)}" target="_blank" class="anchor" href="${safeHref}">${encodeHTML(text)}</a>`;
+            })
     
         if (inlineBlock)
             // Treat both inline code and code blocks as inline code
@@ -586,7 +590,7 @@ addEventListener('DOMContentLoaded', () => {
                 for (const [i, embed] of (object.embeds.length ? object.embeds : [{}]).entries()) {
                     const guiEmbedName = gui.appendChild(child.cloneNode(true))
 
-                    guiEmbedName.querySelector('.text').innerHTML = `Embed ${i + 1}${embed.title ? `: <span>${embed.title}</span>` : ''}`;
+                    guiEmbedName.querySelector('.text').innerHTML = `Embed ${i + 1}${embed.title ? `: <span>${encodeHTML(embed.title)}</span>` : ''}`;
                     guiEmbedName.querySelector('.icon').addEventListener('click', () => {
                         object.embeds.splice(i, 1);
                         buildGui();
@@ -800,7 +804,7 @@ addEventListener('DOMContentLoaded', () => {
                                 embedObj.title = value;
                                 const guiEmbedName = el.target.closest('.guiEmbed')?.previousElementSibling;
                                 if (guiEmbedName?.classList.contains('guiEmbedName'))
-                                    guiEmbedName.querySelector('.text').innerHTML = `${guiEmbedName.innerText.split(':')[0]}${value ? `: <span>${value}</span>` : ''}`;
+                                    guiEmbedName.querySelector('.text').innerHTML = `${guiEmbedName.innerText.split(':')[0]}${value ? `: <span>${encodeHTML(value)}</span>` : ''}`;
                                 buildEmbed({ only: 'embedTitle', index: guiEmbedIndex(el.target) });
                                 break;
                             case 'editAuthorName':

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -457,8 +457,8 @@ addEventListener('DOMContentLoaded', () => {
 
             // parse text in brackets and then the URL in parentheses.
             .replace(/\[([^\[\]]+)\]\((.+?)\)/g, (_, text, href) => {
-                if (!/^https?:\/\//i.test(href)) return text;
-                const safeHref = href.replace(/"/g, '&quot;');
+                if (!/^https?:\/\//i.test(href)) return encodeHTML(text);
+                const safeHref = encodeHTML(href);
                 return `<a title="${encodeHTML(text)}" target="_blank" class="anchor" href="${safeHref}">${encodeHTML(text)}</a>`;
             })
     


### PR DESCRIPTION
## Summary

- **Markdown link XSS (HIGH):** The regex replacing `[text](url)` markdown syntax injected the URL directly into `href` without validation. A `javascript:` protocol URL (e.g. `[click](javascript:alert(1))`) would execute arbitrary JS. The fix validates that only `http://` and `https://` URLs produce links, escapes quotes in the href, and HTML-encodes the link text via `encodeHTML`.
- **Embed title innerHTML XSS (MEDIUM):** `embed.title` from user-provided JSON was inserted into `innerHTML` without escaping in two places (GUI embed name display on load and on edit). The fix applies `encodeHTML()` to the title/value before insertion.

## Test plan

- [ ] Enter `[click me](javascript:alert(1))` in an embed description and verify it renders as plain text, not a clickable link
- [ ] Enter `[legit](https://example.com)` and verify it still renders as a working link
- [ ] Enter `[test](data:text/html,<script>alert(1)</script>)` and verify it renders as plain text
- [ ] Set an embed title to `<img src=x onerror=alert(1)>` via JSON input and verify the HTML is escaped in the sidebar embed name
- [ ] Edit an embed title in the GUI to `<script>alert(1)</script>` and verify it appears as escaped text

## Summary by Sourcery

Harden markdown rendering and embed title handling against XSS injection vectors.

Bug Fixes:
- Sanitize markdown link parsing so only http/https URLs become clickable links and link text is HTML-escaped to prevent script injection via href or link text.
- Escape embed titles before inserting them into innerHTML in both initial render and edit flows to prevent XSS from user-controlled embed names.